### PR TITLE
feat: add PostgreSQL HA role implementation with repmgr + keepalived

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,68 @@ Requirements
   - PostgreSQL ports (`5432`)
   - Repmgr ports (default `5432`, can vary)
   - Keepalived/VRRP protocol (protocol number `112`)
+- Proper `pg_hba.conf` configuration to allow replication and repmgr connections. A minimal example snippet:
+  ```
+  # Allow replication connections from all nodes
+  host    replication     repmgr          192.168.34.0/24          md5
+  # Allow repmgr user connections for monitoring and management
+  host    all             repmgr          192.168.34.0/24          md5
+  ```
 
 Role Variables
 --------------
 
 The following variables are configurable:
 
-| Variable                    | Default                  | Description                                                  |
-|-----------------------------|--------------------------|--------------------------------------------------------------|
-| `postgresql_ha_vip`         | `192.168.1.100`          | Virtual IP (VIP) address shared by the PostgreSQL cluster.   |
-| `postgresql_ha_interface`   | `eth0`                   | Network interface for the VIP                                |
-| `postgresql_ha_router_id`   | `51`                     | VRRP router ID used by Keepalived                            |
-| `postgresql_ha_priority`    | Primary: `100`, Standby: `90` | Priority of Keepalived (Master has higher priority)          |
-| `postgresql_ha_auth_pass`   | `securepass`             | Authentication password for VRRP                             |
-| `postgresql_ha_nodes`       | see defaults             | List of nodes participating in HA                            |
-| `postgresql_ha_initial_primary` | `false`              | Set to `true` for initial Primary server, otherwise `false`  |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `postgresql_version` | `"14.18"` | Full PostgreSQL version |
+| `postgresql_version_major` | `"{{ postgresql_version \| split('.') \| first }}"` | Major version number |
+| `postgresql_daemon` | `"postgresql-{{ postgresql_version_major }}"` | PostgreSQL systemd service name |
+| `postgresql_repmgr_host` | `"{{ ansible_facts['default_ipv4']['address'] }}"` | Local node IP for repmgr |
+| `postgresql_repmgr_node_id` | `1` | Unique integer node ID |
+| `postgresql_data_dir` | `"/var/lib/pgsql/{{ postgresql_version_major }}/data"` | PostgreSQL data directory |
+| `postgresql_bin_path` | `"/usr/pgsql-{{ postgresql_version_major }}/bin"` | PostgreSQL binaries path |
+| `postgresql_config_path` | `"/var/lib/pgsql/{{ postgresql_version_major }}/data"` | PostgreSQL configuration directory |
+| `postgresql_ha_vip_cidr` | `192.168.34.100/24` | VIP with CIDR notation for HA |
+| `postgresql_ha_vip_if` | `ens192` | Interface for the VIP |
+| `postgresql_ha_hosts` | `["192.168.34.11", "192.168.34.12"]` | List of cluster node IPs |
+| `postgresql_repmgr_peer` | `{{ postgresql_ha_hosts \| difference(postgresql_repmgr_host) \| first }}` | Peer node address |
+| `postgresql_ha_initial_role` | `"primary"` | Initial role: `primary` or `standby` |
+| `postgresql_repmgr_password` | `"repmgrpa"` | Password for the `repmgr` user |
+
+Features
+--------
+
+This role includes several tools and configurations to ensure smooth PostgreSQL HA operation:
+
+- **Health check script `check_postgres.sh`**: Verifies primary write availability and standby replication status to ensure cluster health.
+- **Follow script `follow.sh`**: Handles automatic rejoin and rewind operations after failover events.
+- **`repmgrd` and `keepalived` managed via systemd**: Both services are configured with autorestart to maintain availability.
+- **Automatic SSH key exchange**: Sets up SSH key-based authentication for the `postgres` user between all cluster nodes to enable seamless communication.
+- **Aliases for common cluster operations**: Installs convenient aliases such as `cluster show`, `switchover`, and `logs` for easier management.
+- **SELinux set to permissive mode (boot persistent)**: Ensures compatibility with repmgr and keepalived without security policy conflicts.
+
+Operational Notes
+-----------------
+
+This role installs several aliases to simplify cluster management. The following table lists the available HA aliases:
+
+| Command         | Description                                                       |
+|-----------------|-------------------------------------------------------------------|
+| `ha-show`       | Show cluster status                                               |
+| `ha-role`       | Show current node role (PRIMARY or STANDBY)                       |
+| `ha-timeline`   | Show current timeline ID                                          |
+| `ha-switch`     | Controlled switchover (run on standby)                            |
+| `ha-pause`      | Pause repmgrd automation                                          |
+| `ha-unpause`    | Unpause repmgrd automation                                        |
+| `ha-paused`     | Show status of repmgrd automation                                 |
+| `ha-status`     | Show systemd status of PostgreSQL, repmgrd, keepalived            |
+| `ha-restart`    | Restart PostgreSQL, repmgrd, keepalived                           |
+| `ha-logs`       | Tail logs from PostgreSQL, repmgrd, keepalived, follow/check scripts |
+| `ha-vip`        | Show current VIP assignment on local node                         |
+| `ha-vip-arp`    | Show ARP neighbors for VIP                                        |
+| `ha-check`      | Run local health check script                                     |
 
 Dependencies
 ------------
@@ -44,12 +91,14 @@ A basic example showing how to set up PostgreSQL HA using this role:
 ```yaml
 - hosts: postgres_cluster
   vars:
-    postgresql_ha_vip: "10.0.0.200"
-    postgresql_ha_interface: "ens192"
-    postgresql_ha_auth_pass: "your-strong-password"
-    postgresql_ha_nodes:
-      - { hostname: "pg-node1", ip: "10.0.0.101", primary: true }
-      - { hostname: "pg-node2", ip: "10.0.0.102", primary: false }
+    postgresql_repmgr_node_id: "{{ ansible_hostname[-2:] | int }}"
+    postgresql_ha_vip_cidr: "10.0.0.200/24"
+    postgresql_ha_vip_if: "ens192"
+    postgresql_ha_hosts:
+      - "10.0.0.101"
+      - "10.0.0.102"
+    postgresql_repmgr_password: "your-strong-password"
 
   roles:
-    - role: your_namespace.postgresql_ha
+    - role: ahu_services.postgresql_ha
+```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,18 @@
 ---
-# defaults file for ahu_services.postgresql_ha
+postgresql_version: "14.18"
+postgresql_version_major: "{{ postgresql_version | split('.') | first }}"
+postgresql_daemon: "postgresql-{{ postgresql_version_major }}"
+postgresql_repmgr_host: "{{ ansible_facts['default_ipv4']['address'] }}"
+postgresql_repmgr_node_id: 1
+postgresql_data_dir: "/var/lib/pgsql/{{ postgresql_version_major }}/data"
+postgresql_bin_path: "/usr/pgsql-{{ postgresql_version_major }}/bin"
+postgresql_config_path: "/var/lib/pgsql/{{ postgresql_version_major }}/data"
+postgresql_ha_vip_cidr: 192.168.34.100/24
+postgresql_ha_vip_if: ens192
+postgresql_ha_hosts:
+  - 192.168.34.11
+  - 192.168.34.12
+postgresql_repmgr_peer: >-
+  {{ postgresql_ha_hosts | difference(postgresql_repmgr_host) | first }}
+postgresql_ha_initial_role: "primary"
+postgresql_repmgr_password: "repmgrpa"

--- a/files/check_postgres.sh
+++ b/files/check_postgres.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+user='repmgr'
+database='repmgr'
+
+# Console output control: enabled if stdout is a TTY, or via flag (-v/--console/--verbose), or env PG_CHECK_CONSOLE=1
+console=0
+if [ -t 1 ]; then console=1; fi
+for arg in "$@"; do
+  case "$arg" in
+    -v|--console|--verbose)
+      console=1
+      ;;
+  esac
+done
+if [ "${PG_CHECK_CONSOLE:-0}" = "1" ]; then console=1; fi
+
+log(){
+  /usr/bin/logger -t pg_check -- "$1"
+  if [ "$console" = "1" ]; then
+    printf '%s - %s\n' "$(date +'%Y-%m-%d %H:%M:%S')" "$1"
+  fi
+}
+
+log "Checking PostgreSQL status..."
+
+# Standby check (local)
+is_standby=$(/usr/bin/psql -U "$user" -d "$database" -tAc "SELECT pg_is_in_recovery()" 2>/dev/null || echo "")
+if [ -z "$is_standby" ]; then
+  log "Error checking recovery mode."
+  exit 1
+fi
+
+if [ "$is_standby" = "t" ]; then
+  # VIP-strict: never succeed on standby
+  log "Node is standby. Returning failure to keep VIP off this node."
+  exit 1
+else
+  log "Node is primary. Verifying writability (read_only should be off, temp write works)."
+
+  # Quick readonly check
+  read_only=$(/usr/bin/psql -U "$user" -d "$database" -tAc "SHOW default_transaction_read_only" 2>/dev/null || echo "")
+  if [ -z "$read_only" ]; then
+    log "Failed to read default_transaction_read_only."
+    exit 1
+  fi
+  if [ "$read_only" != "off" ]; then
+    log "Instance reports read-only mode ($read_only)."
+    exit 1
+  fi
+
+  # Lightweight write probe using TEMP table (lives in session only)
+  if ! /usr/bin/psql -U "$user" -d "$database" -v ON_ERROR_STOP=1 -q <<'SQL'
+BEGIN;
+CREATE TEMP TABLE _vip_check(x int);
+INSERT INTO _vip_check VALUES (1);
+DROP TABLE _vip_check;
+COMMIT;
+SQL
+  then
+    log "Writable check via TEMP table failed."
+    exit 1
+  fi
+
+  log "Primary is writable. PostgreSQL is working properly."
+  exit 0
+fi

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,21 @@
 ---
-# handlers file for ahu_services.postgresql_ha
+# handlers file for oracle-to-pgsql
+- name: Restart postgresql
+  ansible.builtin.systemd:
+    name: "{{ postgresql_daemon }}"
+    state: restarted
+  become: true
+
+- name: Restart repmgr
+  ansible.builtin.systemd:
+    name: "repmgrd"
+    state: restarted
+    daemon_reload: true
+  become: true
+
+- name: Restart keepalived
+  ansible.builtin.systemd:
+    name: "keepalived"
+    state: restarted
+    daemon_reload: true
+  become: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,11 @@
+---
+- name: Check Repmgr cluster status
+  ansible.builtin.command: "repmgr cluster show"
+  become: true
+  become_user: postgres
+  register: repmgr_cluster_status
+  changed_when: false
+
+- name: Debug Repmgr cluster status
+  ansible.builtin.debug:
+    var: repmgr_cluster_status.stdout_lines

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,16 @@
+---
+- name: Install Repmgr and Keepalived
+  become: true
+  ansible.builtin.dnf:
+    name:
+      - "repmgr_{{ postgresql_version_major }}"
+      - keepalived
+    state: present
+
+- name: Add psql/bin to postgres users PATH
+  become: true
+  become_user: postgres
+  ansible.builtin.lineinfile:
+    path: /var/lib/pgsql/.bash_profile
+    line: 'export PATH=$PATH:{{ postgresql_bin_path }}'
+    state: present

--- a/tasks/keepalived.yml
+++ b/tasks/keepalived.yml
@@ -1,0 +1,59 @@
+---
+- name: Set SELinux to permissive (boot persistent)
+  become: true
+  ansible.posix.selinux:
+    state: permissive
+    policy: targeted
+
+- name: Ensure /var/log/update_keepalived_priority.log exists
+  become: true
+  ansible.builtin.file:
+    path: /var/log/update_keepalived_priority.log
+    state: touch
+    modification_time: preserve
+    access_time: preserve
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Deploy Keepalived configuration
+  become: true
+  ansible.builtin.template:
+    src: keepalived.conf.j2
+    dest: /etc/keepalived/keepalived.conf
+    mode: "0644"
+  notify: Restart keepalived
+
+- name: Deploy check_postgres.sh script
+  become: true
+  ansible.builtin.copy:
+    src: check_postgres.sh
+    dest: /usr/local/bin/check_postgres.sh
+    mode: "0755"
+    owner: root
+    group: root
+
+- name: Deploy update_keepalived_priority.sh script
+  become: true
+  ansible.builtin.template:
+    src: update_keepalived_priority.sh.j2
+    dest: /usr/local/bin/update_keepalived_priority.sh
+    mode: "0755"
+    owner: root
+    group: root
+
+- name: Set cronjob to update Keepalived priority
+  become: true
+  ansible.builtin.cron:
+    name: "Update Keepalived priority"
+    minute: "*"
+    job: "/usr/local/bin/update_keepalived_priority.sh"
+    state: present
+
+- name: Allow VRRP (protocol 112) in firewalld
+  become: true
+  ansible.posix.firewalld:
+    protocol: vrrp
+    permanent: true
+    state: enabled
+    immediate: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,23 @@
 ---
-# tasks file for ahu_services.postgresql_ha
+- name: Debug test message
+  ansible.builtin.debug:
+    msg: >
+      This is node {{ postgresql_repmgr_node_id }} with IP {{ postgresql_repmgr_host }}.
+
+- name: Install required packages
+  ansible.builtin.import_tasks: install.yml
+
+- name: Deploy failover and monitoring scripts
+  ansible.builtin.import_tasks: scripts.yml
+
+- name: Configure Repmgr
+  ansible.builtin.import_tasks: repmgr.yml
+
+- name: Configure SSH for repmgr switchover
+  ansible.builtin.import_tasks: repmgr_ssh.yml
+
+- name: Configure Keepalived
+  ansible.builtin.import_tasks: keepalived.yml
+
+# - name: Final configuration and service activation
+#   ansible.builtin.import_tasks: configure.yml

--- a/tasks/repmgr.yml
+++ b/tasks/repmgr.yml
@@ -1,0 +1,113 @@
+---
+- name: Configure postgresql
+  become: true
+  become_user: postgres
+  ansible.builtin.lineinfile:
+    path: "{{ postgresql_config_path }}/postgresql.conf"
+    regexp: '^{{ item.key }}\s*='
+    line: "{{ item.key }} = {{ item.value }}"
+  notify: Restart postgresql
+  loop:
+    - { key: 'wal_log_hints', value: 'on' }
+    - { key: 'wal_keep_size', value: '64MB' }
+
+- name: Get current shared_preload_libraries
+  # noqa command-instead-of-module
+  become: true
+  become_user: postgres
+  changed_when: false
+  check_mode: false
+  ansible.builtin.command: "sed -nE \"s/{{ sed_pattern }}/\\1/p\" {{ postgresql_config_path }}/postgresql.conf"
+  register: shared_preload_libraries_sed
+  vars:
+    sed_pattern: "^[[:space:]]*shared_preload_libraries[[:space:]]*=[[:space:]]*'([^']*)'.*"
+
+- name: Set shared_preload_libraries
+  ansible.builtin.set_fact:
+    shared_preload_libraries: >-
+      {{
+        (shared_preload_libraries_sed.stdout
+          | split(',')
+          | reject('equalto', '')
+          | list
+          + ['repmgr'])
+        | map('trim')
+        | unique
+        | join(',')
+      }}
+
+- name: Configure shared_preload_libraries
+  become: true
+  become_user: postgres
+  ansible.builtin.lineinfile:
+    path: "{{ postgresql_config_path }}/postgresql.conf"
+    regexp: '^{{ item.key }}\s*='
+    line: "{{ item.key }} = {{ item.value }}"
+  notify: Restart postgresql
+  loop:
+    - { key: 'shared_preload_libraries', value: "'{{ shared_preload_libraries }}'" }
+
+- name: Configure sudoers for repmgr
+  become: true
+  ansible.builtin.copy:
+    content: |
+      postgres ALL=(ALL) NOPASSWD: /usr/bin/systemctl start postgresql-{{ postgresql_version_major }}
+      postgres ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop postgresql-{{ postgresql_version_major }}
+      postgres ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart postgresql-{{ postgresql_version_major }}
+      postgres ALL=(ALL) NOPASSWD: /usr/bin/systemctl reload postgresql-{{ postgresql_version_major }}
+      postgres ALL=(ALL) NOPASSWD: /usr/bin/systemctl start repmgrd
+      postgres ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop repmgrd
+      postgres ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart repmgrd
+      postgres ALL=(ALL) NOPASSWD: /usr/bin/systemctl reload repmgrd
+    dest: /etc/sudoers.d/repmgr
+    mode: "0440"
+
+- name: Create PostgreSQL replication superuser repmgr
+  become: true
+  become_user: postgres
+  community.postgresql.postgresql_user:
+    state: present
+    name: repmgr
+    password: "{{ postgresql_repmgr_password }}"
+    role_attr_flags: "SUPERUSER,CREATEROLE,CREATEDB"
+    quote_configuration_values: false
+    configuration:
+      search_path: repmgr, public
+
+- name: Create repmgr database
+  become: true
+  become_user: postgres
+  community.postgresql.postgresql_db:
+    name: repmgr
+    owner: repmgr
+    state: present
+
+- name: Deploy repmgr.conf configuration
+  become: true
+  ansible.builtin.template:
+    src: repmgr.conf.j2
+    dest: "/etc/repmgr/{{ postgresql_version_major }}/repmgr.conf"
+    owner: postgres
+    mode: "0644"
+  notify: Restart repmgr
+
+- name: Check if any node is already registered
+  community.postgresql.postgresql_query:
+    login_db: repmgr
+    query: "SELECT 1 FROM repmgr.nodes WHERE node_name = '{{ ansible_hostname }}'"
+  failed_when: false
+  check_mode: false
+  changed_when: false
+  register: repmgr_node_check
+
+- name: Initial node registration tasks
+  when: repmgr_node_check.query_result | length == 0
+  ansible.builtin.include_tasks: repmgr_initial_registration.yml
+
+- name: Start repmgr service
+  become: true
+  ansible.builtin.systemd:
+    name: "repmgrd"
+    state: started
+    daemon_reload: true
+    enabled: true

--- a/tasks/repmgr_initial_registration.yml
+++ b/tasks/repmgr_initial_registration.yml
@@ -1,0 +1,34 @@
+---
+- name: Register primary node with repmgr
+  # noqa no-changed-when
+  become: true
+  become_user: postgres
+  ansible.builtin.command: "repmgr -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf primary register"
+  when: postgresql_ha_initial_role == "primary"
+- name: Stop postgresql service before cloning
+  become: true
+  become_user: postgres
+  ansible.builtin.systemd:
+    name: "{{ postgresql_daemon }}"
+    state: stopped
+  when: postgresql_ha_initial_role == "standby"
+- name: Clone to standby node
+  # noqa no-changed-when
+  become: true
+  become_user: postgres
+  ansible.builtin.command: >-
+    repmgr -h {{ postgresql_repmgr_peer }} -U repmgr -d repmgr -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf standby clone -F
+  when: postgresql_ha_initial_role == "standby"
+- name: Start postgresql service after cloning
+  become: true
+  become_user: postgres
+  ansible.builtin.systemd:
+    name: "{{ postgresql_daemon }}"
+    state: started
+  when: postgresql_ha_initial_role == "standby"
+- name: Register standby node with repmgr
+  # noqa no-changed-when
+  become: true
+  become_user: postgres
+  ansible.builtin.command: "repmgr -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf standby register"
+  when: postgresql_ha_initial_role == "standby"

--- a/tasks/repmgr_ssh.yml
+++ b/tasks/repmgr_ssh.yml
@@ -1,0 +1,62 @@
+---
+# SSH setup for repmgr switchover (postgres <-> postgres)
+- name: Ensure ssh-keygen is available
+  become: true
+  ansible.builtin.dnf:
+    name: openssh-clients
+    state: present
+
+- name: Ensure .ssh directory exists with correct permissions
+  become: true
+  ansible.builtin.file:
+    path: /var/lib/pgsql/.ssh
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: '0700'
+
+- name: Generate SSH key for postgres user if not present
+  become: true
+  become_user: postgres
+  community.crypto.openssh_keypair:
+    path: /var/lib/pgsql/.ssh/id_rsa
+    type: rsa
+    size: 4096
+    owner: postgres
+    group: postgres
+    mode: '0600'
+
+- name: Read public key
+  become: true
+  become_user: postgres
+  ansible.builtin.slurp:
+    src: /var/lib/pgsql/.ssh/id_rsa.pub
+  register: repmgr_ssh_pub
+
+- name: Compute HA peer list for SSH exchange
+  ansible.builtin.set_fact:
+    repmgr_ssh_peers: "{{ ansible_play_hosts | difference([inventory_hostname]) }}"
+
+- name: Ensure ~/.ssh exists on peers with correct permissions
+  become: true
+  ansible.builtin.file:
+    path: /var/lib/pgsql/.ssh
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: '0700'
+  loop: "{{ repmgr_ssh_peers }}"
+  loop_control:
+    label: "{{ item }}"
+  delegate_to: "{{ item }}"
+  when: repmgr_ssh_peers | length > 0
+
+- name: Distribute postgres SSH keys to other cluster nodes
+  become: true
+  become_user: postgres
+  ansible.posix.authorized_key:
+    user: postgres
+    key: "{{ repmgr_ssh_pub['content'] | b64decode }}"
+  delegate_to: "{{ item }}"
+  loop: "{{ repmgr_ssh_peers }}"
+  when: repmgr_ssh_peers | length > 0

--- a/tasks/scripts.yml
+++ b/tasks/scripts.yml
@@ -1,0 +1,57 @@
+---
+- name: Configure repmgr run dir
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/tmpfiles.d/repmgrd.conf
+    content: "d /run/repmgr 0755 postgres postgres -\n"
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Ensure /var/log/repmgr exists
+  become: true
+  ansible.builtin.file:
+    path: /var/log/repmgr
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: '0755'
+
+- name: Ensure /var/log/repmgr/repmgr.log exists
+  become: true
+  ansible.builtin.file:
+    path: /var/log/repmgr/repmgr.log
+    state: touch
+    modification_time: preserve
+    access_time: preserve
+    owner: postgres
+    group: postgres
+    mode: '0644'
+
+- name: Deploy follow script
+  become: true
+  ansible.builtin.template:
+    src: follow.sh.j2
+    dest: /usr/local/bin/follow.sh
+    owner: root
+    group: postgres
+    mode: "0755"
+
+- name: Deploy pgsql HA aliases script
+  become: true
+  ansible.builtin.template:
+    src: pgsql_ha_aliases.sh.j2
+    dest: /etc/profile.d/pgsql_ha_aliases.sh
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Deploy repmgrd service file
+  become: true
+  ansible.builtin.template:
+    src: repmgrd.service.j2
+    dest: "/etc/systemd/system/repmgrd.service"
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart repmgr

--- a/templates/follow.sh.j2
+++ b/templates/follow.sh.j2
@@ -1,0 +1,146 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure directories created by repmgr are accessible
+umask 0077
+
+# Binaries and PATH
+repmgr_bin=/usr/pgsql-{{ postgresql_version_major }}/bin/repmgr
+psql_bin=/usr/pgsql-{{ postgresql_version_major }}/bin/psql
+export PATH=/usr/pgsql-{{ postgresql_version_major }}/bin:/usr/bin:/bin:/sbin
+
+# Config
+REPMGR_CONFIG="/etc/repmgr/{{ postgresql_version_major }}/repmgr.conf"
+
+# Determine upstream peer IP from inventory variables:
+# - postgresql_repmgr_host: local node IP (or autodetected default ipv4)
+# - postgresql_ha_hosts: list of both nodes' IPs; pick the one that's not ours
+{% set _local_ip = (postgresql_repmgr_host | default(ansible_facts['default_ipv4']['address'])) %}
+{% set _peers = postgresql_ha_hosts | default([]) %}
+{% set _peer_ip = (_peers | difference([_local_ip]) | first) if _peers else None %}
+PRIMARY_CONNINFO="{{ ('host=' ~ _peer_ip ~ ' ') if _peer_ip else '' }}dbname=repmgr user=repmgr connect_timeout=2"
+PEER_IP="{{ _peer_ip | default('') }}"
+
+MAX_WAIT=30
+RETRY_INTERVAL=5
+RETRY_COUNT=5
+
+log(){ /usr/bin/logger -t follow -- "$1"; }
+run_and_log(){ "$@" 2>&1 | /usr/bin/logger -t follow -- ; return ${PIPESTATUS[0]}; }
+
+log "Checking PostgreSQL status..."
+
+# 1) Standby detection (local, no -h)
+IS_STANDBY=$("$psql_bin" -U repmgr -d repmgr -tAc "SELECT pg_is_in_recovery()" || echo "")
+
+if [ "$IS_STANDBY" = "t" ]; then
+  log "Node is already standby, running follow command."
+
+  # Determine this node's repmgr slot name dynamically (repmgr_slot_<node_id>)
+  NODE_LINE=$("$repmgr_bin" -f "$REPMGR_CONFIG" cluster show | grep -E "\|\s*$(hostname -s)\s*\|") || true
+  NODE_ID=""
+  if [ -n "$NODE_LINE" ]; then
+    NODE_ID=$(echo "$NODE_LINE" | awk -F'|' '{gsub(/ /,"",$1); print $1}')
+  fi
+  SLOT_NAME=""
+  if [ -n "$NODE_ID" ]; then
+    SLOT_NAME="repmgr_slot_${NODE_ID}"
+  fi
+
+  # On the primary (peer), free/drop this standby's slot if it exists (handles active pid as well)
+  if [ -n "$PEER_IP" ] && [ -n "$SLOT_NAME" ]; then
+    SLOT_EXISTS=$("$psql_bin" -h "$PEER_IP" -d postgres -Atc \
+      "SELECT 1 FROM pg_replication_slots WHERE slot_name='${SLOT_NAME}'" 2>/dev/null || echo "")
+    if [ "$SLOT_EXISTS" = "1" ]; then
+      log "Dropping replication slot '${SLOT_NAME}' on primary ($PEER_IP)..."
+      "$psql_bin" -h "$PEER_IP" -d postgres -c \
+        "SELECT pg_terminate_backend(active_pid)
+         FROM pg_replication_slots
+         WHERE slot_name='${SLOT_NAME}' AND active" 2>/dev/null || true
+      "$psql_bin" -h "$PEER_IP" -d postgres -c \
+        "SELECT pg_drop_replication_slot('${SLOT_NAME}')" 2>/dev/null || true
+    fi
+  fi
+
+  run_and_log "$repmgr_bin" standby follow -f "$REPMGR_CONFIG" --log-to-file || true
+  log "Unpausing repmgr service and restarting repmgrd..."
+  "$repmgr_bin" -f "$REPMGR_CONFIG" service unpause || true
+  sudo systemctl restart repmgrd || true
+  exit 0
+fi
+
+# 2) Local primary: check peer directly; if peer is also primary, rejoin this node as standby
+if [ -z "$PEER_IP" ]; then
+  log "No peer IP resolved from postgresql_ha_hosts; skipping rejoin check."
+  exit 0
+fi
+
+# Ask peer directly if it's in recovery: f => peer is PRIMARY; t => peer is STANDBY
+PEER_RECOVERY=$("$psql_bin" -h "$PEER_IP" -U repmgr -d repmgr -Atqc "SELECT pg_is_in_recovery()" || echo "")
+
+if [ "$PEER_RECOVERY" = "f" ]; then
+  log "Conflicting primary detected on peer $PEER_IP. Rejoining this node as standby."
+
+  log "Stopping PostgreSQL service..."
+  sudo systemctl stop postgresql-{{ postgresql_version_major }} || true
+
+  # Wait for PostgreSQL service to stop (keep article logic)
+  WAIT_TIME=0
+  while systemctl is-active --quiet postgresql-{{ postgresql_version_major }}; do
+    sleep 1
+    WAIT_TIME=$((WAIT_TIME+1))
+    if [ $WAIT_TIME -ge $MAX_WAIT ]; then
+      log "PostgreSQL service did not stop within $MAX_WAIT seconds. Exiting rejoin process."
+      exit 1
+    fi
+  done
+  log "PostgreSQL service stopped successfully."
+
+  sleep 6
+
+  # Clean up possible stale config archive dir from previous rejoin attempts
+  TMP_ARCHIVE_DIR="/tmp/repmgr-config-archive-$(hostname -s)"
+  if [ -e "$TMP_ARCHIVE_DIR" ]; then
+    log "Found stale config archive dir: $TMP_ARCHIVE_DIR — removing"
+    rm -rf "$TMP_ARCHIVE_DIR" 2>/dev/null || true
+  fi
+
+  # Retry logic for repmgr node rejoin (against peer IP)
+  RETRY=0
+  while [ $RETRY -lt $RETRY_COUNT ]; do
+    log "Running repmgr node rejoin (attempt $((RETRY+1))/$RETRY_COUNT)..."
+    run_and_log "$repmgr_bin" node rejoin -f "$REPMGR_CONFIG" \
+      -d "host=$PEER_IP dbname=repmgr user=repmgr connect_timeout=2" \
+      --force-rewind --config-files=postgresql.local.conf,postgresql.conf --verbose
+    if [ $? -eq 0 ]; then
+      log "Rejoin successful."
+      break
+    else
+      log "Rejoin failed, retrying in $RETRY_INTERVAL seconds..."
+      sleep $RETRY_INTERVAL
+      RETRY=$((RETRY+1))
+    fi
+  done
+
+  if [ $RETRY -eq $RETRY_COUNT ]; then
+    log "Rejoin failed after $RETRY_COUNT attempts. Forcing PostgreSQL to start."
+    sudo systemctl start postgresql-{{ postgresql_version_major }}
+    sleep 6
+  else
+    log "Starting PostgreSQL service..."
+    sudo systemctl start postgresql-{{ postgresql_version_major }}
+    sleep 6
+  fi
+
+  log "Starting repmgrd service..."
+  "$repmgr_bin" -f "$REPMGR_CONFIG" service unpause || true
+  sudo systemctl restart repmgrd || true
+
+  log "Follow script completed."
+else
+  if [ "$PEER_RECOVERY" = "t" ]; then
+    log "Peer $PEER_IP is standby; keeping local primary role."
+  else
+    log "Peer $PEER_IP unreachable or error; keeping local primary role."
+  fi
+fi

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -1,0 +1,34 @@
+global_defs {
+    script_user postgres
+    enable_script_security
+}
+
+
+vrrp_script pg_check {
+      script "/usr/local/bin/check_postgres.sh"
+      interval 2
+      timeout 2
+      rise 1
+      fall 3
+}
+
+
+vrrp_instance VI_1 {
+    state {{ 'MASTER' if postgresql_ha_initial_role == 'primary' else 'BACKUP' }}
+    interface {{ postgresql_ha_vip_if }}
+    virtual_router_id 51
+    priority {{ 100 if postgresql_ha_initial_role == 'primary' else 90 }}
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass {{ postgresql_repmgr_password }}
+    }
+    virtual_ipaddress {
+        {{ postgresql_ha_vip_cidr }} dev {{ postgresql_ha_vip_if }}
+    }
+    track_script {
+        pg_check
+    }
+    notify_backup "/usr/local/bin/follow.sh"
+    notify_fault "/usr/local/bin/follow.sh"
+}

--- a/templates/pgsql_ha_aliases.sh.j2
+++ b/templates/pgsql_ha_aliases.sh.j2
@@ -1,0 +1,36 @@
+# PostgreSQL HA convenience aliases (global)
+# Shell: bash (works in other POSIX shells for simple aliases too)
+
+# tune these two if you ever change versions or VIP
+export HA_PGVER={{ postgresql_version_major }}
+export HA_VIP={{ postgresql_ha_vip_cidr }}
+
+# common binaries
+export HA_REPMGR="/usr/pgsql-${HA_PGVER}/bin/repmgr"
+export HA_PSQL="/usr/pgsql-${HA_PGVER}/bin/psql"
+export HA_REPMGR_CONF="/etc/repmgr/${HA_PGVER}/repmgr.conf"
+
+# ---- cluster introspection ----
+alias ha-show="sudo -iu postgres ${HA_REPMGR} -f ${HA_REPMGR_CONF} cluster show"
+alias ha-role='sudo -iu postgres ${HA_PSQL} -d postgres -Atqc "select case when pg_is_in_recovery() then '\''STANDBY'\'' else '\''PRIMARY'\'' end"'
+alias ha-timeline='sudo -iu postgres ${HA_PSQL} -d postgres -Atqc "select timeline_id from pg_control_checkpoint()"'
+
+# ---- controlled switchover (run on current STANDBY) ----
+alias ha-switch="sudo -iu postgres ${HA_REPMGR} -f ${HA_REPMGR_CONF} standby switchover --siblings-follow"
+
+# ---- maintenance helpers (pause/unpause repmgrd automation) ----
+alias ha-pause="sudo -iu postgres ${HA_REPMGR} service pause"
+alias ha-unpause="sudo -iu postgres ${HA_REPMGR} service unpause"
+alias ha-paused="sudo -iu postgres ${HA_REPMGR} service status"
+
+# ---- services & logs ----
+alias ha-status='systemctl status postgresql-'${HA_PGVER}' repmgrd keepalived'
+alias ha-restart='sudo systemctl restart postgresql-'${HA_PGVER}' repmgrd keepalived'
+alias ha-logs='sudo journalctl -u postgresql-'${HA_PGVER}' -u repmgrd -u keepalived -t follow -t pg_check -f'
+
+# ---- VIP checks ----
+alias ha-vip='ip -br addr show | grep -E " ${HA_VIP%%/*}|${HA_VIP}$" || true'
+alias ha-vip-arp='ip neigh show | grep -F ${HA_VIP%%/*} || true'
+
+# ---- local health script (your keepalived check) ----
+alias ha-check='/usr/local/bin/check_postgres.sh'

--- a/templates/repmgr.conf.j2
+++ b/templates/repmgr.conf.j2
@@ -1,0 +1,23 @@
+node_id={{ postgresql_repmgr_node_id }}
+node_name='{{ ansible_hostname }}'
+conninfo='host={{ postgresql_repmgr_host }} user=repmgr dbname=repmgr connect_timeout=2'
+data_directory='{{ postgresql_data_dir}}'
+use_replication_slots=1
+log_level=INFO
+log_file='/var/log/repmgr/repmgr.log'
+pg_bindir='{{ postgresql_bin_path }}'
+promote_command='{{ postgresql_bin_path }}/repmgr standby promote -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf --log-to-file'
+follow_command='{{ postgresql_bin_path }}/repmgr standby follow -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf --log-to-file --upstream-node-id=%n'
+standby_disconnect_on_failover=true
+failover='automatic'
+reconnect_attempts=6
+reconnect_interval=10
+monitor_interval_secs=2
+node_rejoin_timeout=30
+standby_reconnect_timeout=30
+log_status_interval=20
+ssh_options='-o "StrictHostKeyChecking=no"'
+service_start_command='sudo /usr/bin/systemctl start postgresql-{{ postgresql_version_major }}'
+service_stop_command='sudo /usr/bin/systemctl stop postgresql-{{ postgresql_version_major }}'
+service_restart_command='sudo /usr/bin/systemctl restart postgresql-{{ postgresql_version_major }}'
+service_reload_command='sudo /usr/bin/systemctl reload postgresql-{{ postgresql_version_major }}'

--- a/templates/repmgrd.service.j2
+++ b/templates/repmgrd.service.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=Manage repmgrd for PostgreSQL
+After=network.target postgresql-{{ postgresql_version_major }}.service
+Requires=postgresql-{{ postgresql_version_major }}.service
+
+[Service]
+Environment=PATH={{ postgresql_bin_path }}:/usr/bin:/bin
+Type=forking
+User=postgres
+ExecStart={{ postgresql_bin_path}}/repmgrd -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf -d --pid-file=/run/repmgr/repmgrd.pid
+PIDFile=/run/repmgr/repmgrd.pid
+ExecStop=/bin/kill -TERM $MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+Restart=always
+RestartSec=5s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=repmgrd
+RuntimeDirectory=repmgr
+RuntimeDirectoryMode=0755
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/update_keepalived_priority.sh.j2
+++ b/templates/update_keepalived_priority.sh.j2
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Configuration
+user='repmgr'
+database='repmgr'
+current_node={{ postgresql_repmgr_host }}
+config_file='/etc/keepalived/keepalived.conf'
+primary_priority=100
+standby_priority=90
+
+
+# Logging function (send to syslog)
+log() {
+    /usr/bin/logger -t keepalived_prio -- "$1"
+}
+
+
+log "Checking PostgreSQL role on node $current_node..."
+
+
+# Check if the node is primary
+is_primary=$(psql -h $current_node -U $user -d $database -tAc "SELECT pg_is_in_recovery()" 2>/dev/null)
+if [ $? -ne 0 ]; then
+    log "Error checking role of the node $current_node."
+    exit 1
+fi
+
+
+# Determine current priority and state in keepalived.conf
+current_priority=$(grep -E "^\s*priority" $config_file | awk '{print $2}')
+current_state=$(grep -E "^\s*state" $config_file | awk '{print $2}')
+
+
+log "Current priority: $current_priority"
+log "Current state: $current_state"
+
+
+# Update the priority and state if they do not match the role
+if [ "$is_primary" == "f" ]; then
+    if [ "$current_priority" -ne $primary_priority ] || [ "$current_state" != "MASTER" ]; then
+        log "Node $current_node is primary. Updating priority to $primary_priority and state to MASTER."
+        sed -i "s/^\s*priority.*/    priority $primary_priority/" $config_file
+        sed -i "s/^\s*state.*/    state MASTER/" $config_file
+        systemctl reload keepalived
+        log "Keepalived priority updated to $primary_priority and state to MASTER. Service reloaded."
+    else
+        log "Node $current_node is primary and keepalived is already set to priority $primary_priority and state MASTER. No changes made."
+    fi
+else
+    if [ "$current_priority" -ne $standby_priority ] || [ "$current_state" != "BACKUP" ]; then
+        log "Node $current_node is standby. Updating priority to $standby_priority and state to BACKUP."
+        sed -i "s/^\s*priority.*/    priority $standby_priority/" $config_file
+        sed -i "s/^\s*state.*/    state BACKUP/" $config_file
+        systemctl reload keepalived
+        log "Keepalived priority updated to $standby_priority and state to BACKUP. Service reloaded."
+    else
+        log "Node $current_node is standby and keepalived is already set to priority $standby_priority and state BACKUP. No changes made."
+    fi
+fi


### PR DESCRIPTION
- Added full defaults for PostgreSQL HA (version, paths, VIP config, peer, roles)
- Implemented tasks to install repmgr and keepalived, configure PostgreSQL, set up sudoers, and manage SSH key exchange for repmgr
- Added `check_postgres.sh` health check script with console/journal output
- Added `follow.sh` script template to handle automatic rejoin/rewind
- Added keepalived configuration and priority update script
- Added systemd service template for repmgrd with autorestart
- Added global convenience aliases for common HA operations (ha-show, ha-switch, ha-status, etc.)
- Updated README:
  - Documented required `pg_hba.conf` entries for replication/repmgr
  - Updated role variables to new schema
  - Documented features (health checks, follow, autorestart, aliases, SELinux permissive)
  - Added operational notes including alias table
  - Updated example playbook
- Added handlers for PostgreSQL, repmgrd, and keepalived restarts
- Ensured logs and runtime directories are created with correct permissions