### PR TITLE
postgresql: improve HA defaults, repmgr robustness, keepalived check & README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following variables are configurable:
 | `postgresql_bin_path` | `"/usr/pgsql-{{ postgresql_version_major }}/bin"` | PostgreSQL binaries path |
 | `postgresql_config_path` | `"/var/lib/pgsql/{{ postgresql_version_major }}/data"` | PostgreSQL configuration directory |
 | `postgresql_ha_vip_cidr` | `192.168.34.100/24` | VIP with CIDR notation for HA |
-| `postgresql_ha_vip_if` | `ens192` | Interface for the VIP |
+| `postgresql_ha_vip_if` | `eth0` | Interface for the VIP |
 | `postgresql_ha_hosts` | `["192.168.34.11", "192.168.34.12"]` | List of cluster node IPs |
 | `postgresql_repmgr_peer` | `{{ postgresql_ha_hosts \| difference(postgresql_repmgr_host) \| first }}` | Peer node address |
 | `postgresql_ha_initial_role` | `"primary"` | Initial role: `primary` or `standby` |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,6 @@ postgresql_ha_hosts:
   - 192.168.34.11
   - 192.168.34.12
 postgresql_repmgr_peer: >-
-  {{ postgresql_ha_hosts | difference(postgresql_repmgr_host) | first }}
+  {{ (postgresql_ha_hosts | difference([postgresql_repmgr_host | string])) | first }}
 postgresql_ha_initial_role: "primary"
 postgresql_repmgr_password: "repmgrpa"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ postgresql_data_dir: "/var/lib/pgsql/{{ postgresql_version_major }}/data"
 postgresql_bin_path: "/usr/pgsql-{{ postgresql_version_major }}/bin"
 postgresql_config_path: "/var/lib/pgsql/{{ postgresql_version_major }}/data"
 postgresql_ha_vip_cidr: 192.168.34.100/24
-postgresql_ha_vip_if: ens192
+postgresql_ha_vip_if: eth0
 postgresql_ha_hosts:
   - 192.168.34.11
   - 192.168.34.12

--- a/tasks/keepalived.yml
+++ b/tasks/keepalived.yml
@@ -51,6 +51,7 @@
     state: present
 
 - name: Allow VRRP (protocol 112) in firewalld
+  when: "'firewalld' in ansible_facts.services and ansible_facts.services['firewalld'].state == 'running'"
   become: true
   ansible.posix.firewalld:
     protocol: vrrp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Debug test message
   ansible.builtin.debug:
     msg: >
-      This is node {{ postgresql_repmgr_node_id }} with IP {{ postgresql_repmgr_host }}.
+      This is node {{ postgresql_repmgr_node_id }} with IP {{ postgresql_repmgr_host }} and peer {{ postgresql_repmgr_peer }}.
 
 - name: Install required packages
   ansible.builtin.import_tasks: install.yml

--- a/tasks/repmgr.yml
+++ b/tasks/repmgr.yml
@@ -101,7 +101,7 @@
   register: repmgr_node_check
 
 - name: Initial node registration tasks
-  when: repmgr_node_check.query_result | length == 0
+  when: (repmgr_node_check.query_result | default([])) | length == 0
   ansible.builtin.include_tasks: repmgr_initial_registration.yml
 
 - name: Start repmgr service

--- a/tasks/repmgr_initial_registration.yml
+++ b/tasks/repmgr_initial_registration.yml
@@ -1,4 +1,6 @@
 ---
+- name: Force all notified handlers to run at this point, not waiting for normal sync points
+  ansible.builtin.meta: flush_handlers
 - name: Register primary node with repmgr
   # noqa no-changed-when
   become: true

--- a/tasks/repmgr_initial_registration.yml
+++ b/tasks/repmgr_initial_registration.yml
@@ -3,7 +3,7 @@
   # noqa no-changed-when
   become: true
   become_user: postgres
-  ansible.builtin.command: "repmgr -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf primary register"
+  ansible.builtin.command: "{{ postgresql_bin_path }}/repmgr -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf primary register"
   when: postgresql_ha_initial_role == "primary"
 - name: Stop postgresql service before cloning
   become: true
@@ -17,7 +17,8 @@
   become: true
   become_user: postgres
   ansible.builtin.command: >-
-    repmgr -h {{ postgresql_repmgr_peer }} -U repmgr -d repmgr -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf standby clone -F
+    {{ postgresql_bin_path }}/repmgr -h {{ postgresql_repmgr_peer }} -U repmgr -d repmgr
+     -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf standby clone -F
   when: postgresql_ha_initial_role == "standby"
 - name: Start postgresql service after cloning
   become: true
@@ -30,5 +31,5 @@
   # noqa no-changed-when
   become: true
   become_user: postgres
-  ansible.builtin.command: "repmgr -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf standby register"
+  ansible.builtin.command: "{{ postgresql_bin_path }}/repmgr -f /etc/repmgr/{{ postgresql_version_major }}/repmgr.conf standby register"
   when: postgresql_ha_initial_role == "standby"

--- a/tasks/repmgr_initial_registration.yml
+++ b/tasks/repmgr_initial_registration.yml
@@ -7,7 +7,6 @@
   when: postgresql_ha_initial_role == "primary"
 - name: Stop postgresql service before cloning
   become: true
-  become_user: postgres
   ansible.builtin.systemd:
     name: "{{ postgresql_daemon }}"
     state: stopped
@@ -22,7 +21,6 @@
   when: postgresql_ha_initial_role == "standby"
 - name: Start postgresql service after cloning
   become: true
-  become_user: postgres
   ansible.builtin.systemd:
     name: "{{ postgresql_daemon }}"
     state: started


### PR DESCRIPTION
Make PostgreSQL HA role more robust:
- update default VIP interface to eth0
- make repmgr peer Jinja expression safer
- use configured postgresql_bin_path for repmgr commands
- guard repmgr when-check against missing query_result
- flush handlers before repmgr registration
- only add VRRP/firewalld rules if firewalld is present & running
- small debug/info improvement in main task and README update